### PR TITLE
showblade 不具合修正

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -73,3 +73,14 @@
     top: 0;
     right: 0;
 }
+
+/* .image-form {
+    position: relative;
+}
+
+.image-form-btn{
+    position: absolute;
+    top:0;
+    right: 10px;
+} */
+

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,0 +1,8 @@
+<script>
+    $(document).ready(function(){
+        $("#sample_img").on(function () {
+            var src = $(this).children('img').attr('src');
+            $("#translate-img").attr("src", src);
+            return false;
+        })});
+</script>

--- a/resources/views/modal/image_modal.blade.php
+++ b/resources/views/modal/image_modal.blade.php
@@ -1,0 +1,60 @@
+<div class="modal fade" id="image_Modal<?php echo $i; ?>" tabindex="-1" role="dialog"
+    aria-labelledby="myLargeModalLabel">
+    <div class="modal-dialog modal-lg modal-middle">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body col-10 mx-auto">
+                <img class="d-block mx-auto" src="{{ Storage::url($image->file_path) }}" width="80%" />
+                <p class="m-0 text-center">{{ $image->file_name }}</p>
+                <hr>
+                <ul class="setting-list p-2">
+                    <li>
+                        <a class="btn btn-outline-primary float-end" data-bs-toggle="collapse"
+                            href="#collapseImageUpdate" role="button" aria-expanded="false"
+                            aria-controls="collapseImageUpdate">
+                            <i class="me-1 fa-solid fa-pen"></i>
+                        </a>
+                        <h4>画像を変更する</h4>
+                        <div class="collapse" id="collapseImageUpdate">
+                            <form method='POST' action="/imageUpdate" enctype="multipart/form-data">
+                                @csrf
+                                <input type="hidden" name='file_path' value="{{ $image->file_path }}">
+                                <input type="hidden" name='diary_date' value="{{ $date }}">
+                                <input type="hidden" name='id' value="{{ $image->id }}">
+                                <div class="form-group d-inline-block">
+                                    <input type="file" name="diary_img" accept="image/png, image/jpeg">
+                                </div>
+                                <input type='submit' class="btn btn-outline-primary" value="画像を変更">
+                            </form>
+                        </div>
+                    </li>
+                    <hr>
+                    <li>
+                        <a class="btn btn-outline-primary float-end" data-bs-toggle="collapse"
+                            href="#collapseImageDelete" role="button" aria-expanded="false"
+                            aria-controls="collapseImageDelete">
+                            <i class="me-1 fa-solid fa-pen"></i>
+                        </a>
+                        <h4>画像を削除する</h4>
+                        <div class="collapse" id="collapseImageDelete">
+                            <form method='POST' action="/imageDelete">
+                                @csrf
+                                <input type="hidden" name='id' value="{{ $image->id }}">
+                                <input type="hidden" name='file_path' value="{{ $image->file_path }}">
+                                <input type="hidden" name='diary_date' value="{{ $date }}">
+                                <button type="submit" class="btn btn-outline-primary btn-lg ms-1"><i
+                                        class="me-1 fa-solid fa-trash-can"></i>画像を削除</button>
+                            </form>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+            <div class="modal-footer">
+
+                <button type="button" class="btn btn-outline-primary" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -44,17 +44,23 @@
                 </div>
 
                 <div class="m-0">
+                    @php
+                        $i = 0;
+                    @endphp
                     @foreach ($images as $image)
                         <div class="rounded float-start img-thumbnail" style="width: 50%;">
-                            <a data-bs-target="#image_Modal" data-bs-toggle="modal">
+                            <a data-bs-target="#image_Modal<?php echo $i; ?>" data-bs-toggle="modal">
                                 <img src="{{ Storage::url($image->file_path) }}" style="width:100%;"
                                     style="cursor:pointer;" />
                             </a>
                             <p class="m-0 text-center">{{ $image->file_name }}</p>
                         </div>
+                        @include('modal.image_modal')
+                        @php
+                            ++$i;
+                        @endphp
                     @endforeach
                 </div>
-
             </div>
         </div>
     @else
@@ -66,41 +72,5 @@
     @endif
     </div>
     @if (!empty($image))
-        <div class="modal fade" id="image_Modal" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel">
-            <div class="modal-dialog modal-lg modal-middle">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h4 class="modal-title" id="Title">タグ設定</h4>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                    </div>
-                    <div class="modal-body">
-                        <img src="{{ Storage::url($image->file_path) }}" width="80%" />
-                    </div>
-                    <p class="m-0 text-center">{{ $image->file_name }}</p>
-                    <hr>
-                    <form method='POST' action="/imageUpdate" enctype="multipart/form-data">
-                        @csrf
-                        <input type="hidden" name='file_path' value="{{ $image->file_path }}">
-                        <input type="hidden" name='diary_date' value="{{ $date }}">
-                        <input type="hidden" name='id' value="{{ $image->id }}">
-                        <div class="form-group">
-                            <input type="file" name="diary_img" accept="image/png, image/jpeg">
-                        </div>
-                        <input type='submit' class="d-block btn btn-outline-primary" value="画像を変更">
-                    </form>
-                    <form method='POST' action="/imageDelete">
-                        @csrf
-                        <input type="hidden" name='id' value="{{ $image->id }}">
-                        <input type="hidden" name='file_path' value="{{ $image->file_path }}">
-                        <input type="hidden" name='diary_date' value="{{ $date }}">
-                        <button type="submit" class="btn btn-outline-primary btn-lg ms-1"><i
-                                class="me-1 fa-solid fa-trash-can"></i>削除</button>
-                    </form>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-outline-primary" data-dismiss="modal">Close</button>
-                    </div>
-                </div>
-            </div>
-        </div>
     @endif
 @endsection


### PR DESCRIPTION
## 修正前
showblade で　別画像のmodalが表示される

## 原因
foreach($images as $image)でmodalの$imageが上書きされていたため

## 解決法
強引だが、modalに固有番号を振った。
しかし、画像の保存枚数に比例してコードが多くなるので、より最適な改善が必要。